### PR TITLE
Handle parens for it, describe, and friends

### DIFF
--- a/lib/testrbl.rb
+++ b/lib/testrbl.rb
@@ -2,9 +2,9 @@ require 'testrbl/version'
 
 module Testrbl
   PATTERNS = [
-    /^(\s+)(should|test|it)\s+['"](.*)['"]\s+do\s*(?:#.*)?$/,
-    /^(\s+)(context|describe)\s+['"]?(.*?)['"]?\s+do\s*(?:#.*)?$/,
-    /^(\s+)def\s+(test_)([a-z_\d]+)\s*(?:#.*)?$/
+    /^(\s+)(should|test|it)(\s+|\s*\(\s*)['"](.*)['"](\s*\))?\s+do\s*(?:#.*)?$/,
+    /^(\s+)(context|describe)(\s+|\s*\(\s*)['"]?(.*?)['"]?(\s*\))?\s+do\s*(?:#.*)?$/,
+    /^(\s+)def(\s+)(test_)([a-z_\d]+)\s*(?:#.*)?$/
   ]
 
   OPTION_WITH_ARGUMENT = ["-I", "-r", "-n", "--name", "-e", "--exclude", "-s", "--seed"]
@@ -154,7 +154,7 @@ module Testrbl
     def test_pattern_from_line(line)
       PATTERNS.each do |r|
         next unless line =~ r
-        whitespace, method, test_name = $1, $2, $3
+        whitespace, method, test_name = $1, $2, $4
         return [whitespace, test_pattern_from_match(method, test_name)]
       end
       nil

--- a/spec/testrbl_spec.rb
+++ b/spec/testrbl_spec.rb
@@ -623,7 +623,7 @@ describe Testrbl do
         call("  it \"xX ._-..  ___ Xx\" do\n").should == ["  ", "#test_\\d+_xX \\._\\-\\.\\.  ___ Xx$"]
       end
 
-      it "finds with pecial characters" do
+      it "finds with special characters" do
         call("  it \"hmm? it's weird\\\"?\" do\n").should == ["  ", "#test_\\d+_hmm\\? it.s weird\\\\\"\\?$"]
       end
     end

--- a/spec/testrbl_spec.rb
+++ b/spec/testrbl_spec.rb
@@ -351,6 +351,12 @@ describe Testrbl do
             puts "-HIJ-"
           end
         end
+
+        describe("h-j") do
+          it "i-k" do
+            puts "-KLM-"
+          end
+        end
       RUBY
     end
 
@@ -377,6 +383,10 @@ describe Testrbl do
 
     it "runs it with parens" do
       run_line("28").should == ["HIJ"]
+    end
+
+    it "runs describe with parens" do
+      run_line("33").should == ["KLM"]
     end
   end
 

--- a/spec/testrbl_spec.rb
+++ b/spec/testrbl_spec.rb
@@ -346,6 +346,10 @@ describe Testrbl do
           it "b./_-d" do
             puts "-EFG-"
           end
+
+          it("f-g") do
+            puts "-HIJ-"
+          end
         end
       RUBY
     end
@@ -369,6 +373,10 @@ describe Testrbl do
 
     it "runs nested it" do
       run_line("13").should == ["CDE"]
+    end
+
+    it "runs it with parens" do
+      run_line("28").should == ["HIJ"]
     end
   end
 


### PR DESCRIPTION
Fixes #7 

* Adds tests that fail before the change and pass after.
* Adds to the patterns to allow parens with potentially no whitespace around the open paren or before the close paren.
* Adjusts third pattern to maintain positional correspondence of capture groups.
* Corrects a typo.

Note that one test fails on master before and after this change.